### PR TITLE
Update http_connection.cr

### DIFF
--- a/src/cossack/connection/http_connection.cr
+++ b/src/cossack/connection/http_connection.cr
@@ -8,7 +8,7 @@ module Cossack
 
       http_response = client.exec(request.method, request.uri.to_s, request.headers, request.body)
       Response.new(http_response.status_code, http_response.headers, http_response.body)
-    rescue err : IO::Timeout
+    rescue err : IO::TimeoutError
       raise TimeoutError.new(err.message, cause: err)
     end
   end


### PR DESCRIPTION
[Crystal PR #8885](https://github.com/crystal-lang/crystal/pull/8885) changed the name of `IO::Timeout` to `IO::TimeoutError`