### PR TITLE
Updated Request body to accept String, Bytes, IO or Nil

### DIFF
--- a/examples/connection_swapping.cr
+++ b/examples/connection_swapping.cr
@@ -1,7 +1,7 @@
 require "../src/cossack"
 
 client = Cossack::Client.new("https://raw.githubusercontent.com")
-client.connection = -> (request : Cossack::Request) do
+client.connection = ->(request : Cossack::Request) do
   Cossack::Response.new(200, "Everything is fine")
 end
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cossack
-version: 0.1.4
+version: 0.1.5
 
 authors:
   - Sergey Potapov <blake131313@gmail.com>
@@ -13,3 +13,4 @@ development_dependencies:
 
   spec2:
     github: waterlink/spec2.cr
+    version: ~> 0.11

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cossack
-version: 0.1.5
+version: 0.1.6
 
 authors:
   - Sergey Potapov <blake131313@gmail.com>

--- a/spec/acceptance/client_spec.cr
+++ b/spec/acceptance/client_spec.cr
@@ -16,7 +16,7 @@ Spec2.describe "Client" do
   end
 
   it "sends User-Agent header by default" do
-    client =  Cossack::Client.new(TEST_SERVER_URL)
+    client = Cossack::Client.new(TEST_SERVER_URL)
     response = client.get("/http/reflect")
     expect(response.headers["REQUEST-HEADER-User-Agent"]?).to eq "Cossack v#{Cossack::VERSION}"
   end

--- a/spec/acceptance/middleware_spec.cr
+++ b/spec/acceptance/middleware_spec.cr
@@ -40,7 +40,7 @@ describe "Middleware usage" do
 
     client = Cossack::Client.new(TEST_SERVER_URL) do |client|
       client.use TestMiddlwareWriter, responses
-      client.connection = -> (req : Cossack::Request) do
+      client.connection = ->(req : Cossack::Request) do
         Cossack::Response.new(201, HTTP::Headers.new, "hello")
       end
       client.get("/")
@@ -53,7 +53,7 @@ describe "Middleware usage" do
 
     client = Cossack::Client.new(TEST_SERVER_URL) do |client|
       client.use TestMiddlwareWriter, responses
-      client.connection = -> (req : Cossack::Request) do
+      client.connection = ->(req : Cossack::Request) do
         Cossack::Response.new(201, HTTP::Headers.new, "hello")
       end
       client.get("/")

--- a/spec/support/server.cr
+++ b/spec/support/server.cr
@@ -12,7 +12,6 @@ module Kemal
   end
 end
 
-
 get "/" do
   "root"
 end
@@ -28,12 +27,12 @@ REFLECT_HANDLER = ->(env : HTTP::Server::Context) do
   env.response.headers["REQUEST-METHOD"] = env.request.method.to_s
   request_body = env.request.body
   body_string = if request_body.nil?
-    ""
-  else
-    sb = String::Builder.new
-    IO.copy(request_body, sb)
-    sb.to_s
-  end
+                  ""
+                else
+                  sb = String::Builder.new
+                  IO.copy(request_body, sb)
+                  sb.to_s
+                end
   env.response.headers["REQUEST-BODY"] = body_string
 
   env.request.headers.each do |name, value|

--- a/spec/unit/connection/connection_mock/request_matcher_spec.cr
+++ b/spec/unit/connection/connection_mock/request_matcher_spec.cr
@@ -6,7 +6,7 @@ Spec2.describe Cossack::TestConnection::RequestMatcher do
 
   let(matcher) { Cossack::TestConnection::RequestMatcher.new(method, url, headers, body) }
   let(method) { nil }
-  let(url) { nil}
+  let(url) { nil }
   let(headers) { {} of String => String }
   let(body) { nil }
 
@@ -61,12 +61,12 @@ Spec2.describe Cossack::TestConnection::RequestMatcher do
 
             context "when headers are given" do
               context "when one of headers do not match" do
-                let(headers) { { "User-Agent" => "Firefox" } }
+                let(headers) { {"User-Agent" => "Firefox"} }
                 it "returns false" { expect(subject).to eq false }
               end
 
               context "when all headers match" do
-                let(headers) { { "User-Agent" => "Cossack" } }
+                let(headers) { {"User-Agent" => "Cossack"} }
                 it "returns true" { expect(subject).to eq true }
 
                 context "when body is specified" do
@@ -77,7 +77,7 @@ Spec2.describe Cossack::TestConnection::RequestMatcher do
 
                   context "when body matches" do
                     let(body) { "The love" }
-                    it "returns true" { expect(subject).to eq true}
+                    it "returns true" { expect(subject).to eq true }
                   end
                 end
               end

--- a/spec/unit/connection/test_connection_spec.cr
+++ b/spec/unit/connection/test_connection_spec.cr
@@ -115,7 +115,7 @@ Spec2.describe Cossack::TestConnection do
     end
 
     context "when body request specified" do
-      let(request_body) { "REQUEST_BODY"}
+      let(request_body) { "REQUEST_BODY" }
       context "when body matches" do
         it "returns response" do
           connection.stub_post("/ping", "REQUEST_BODY", {200, "pong"})

--- a/spec/unit/middleware/cookie_jar_middleware_spec.cr
+++ b/spec/unit/middleware/cookie_jar_middleware_spec.cr
@@ -1,6 +1,6 @@
 require "../../spec_helper"
 
-Spec2.describe Cossack::CookieJarMiddleware do
+describe Cossack::CookieJarMiddleware do
   let(connection) { Cossack::TestConnection.new }
   let(cookie_jar) { Cossack::CookieJar.new }
   let(middleware) { Cossack::CookieJarMiddleware.new(connection, cookie_jar) }
@@ -11,21 +11,21 @@ Spec2.describe Cossack::CookieJarMiddleware do
 
   before do
     connection.stub_get("http://example.com/abc/check_cookies", {
-      "Cookie" => cookie.to_cookie_header
+      "Cookie" => cookie.to_cookie_header,
     }, {
       200,
-      "OK"
+      "OK",
     })
     connection.stub_get("http://example.com/abc/check_cookies", {
       200,
-      "Not OK"
+      "Not OK",
     })
     connection.stub_get("http://example.com/abc/set_cookies", {
       200,
       {
-        "Set-Cookie" => cookie.to_set_cookie_header
+        "Set-Cookie" => cookie.to_set_cookie_header,
       },
-      "OK"
+      "OK",
     })
   end
 

--- a/spec/unit/response_spec.cr
+++ b/spec/unit/response_spec.cr
@@ -34,11 +34,11 @@ Spec2.describe Cossack::Response do
   describe "status methods" do
     describe "#success?" do
       it "returns true for 2xx responses" do
-        { 199 => false,
-          200 => true,
-          204 => true,
-          299 => true,
-          300 => false
+        {199 => false,
+         200 => true,
+         204 => true,
+         299 => true,
+         300 => false,
         }.each do |status, expected_value|
           response = Cossack::Response.new(status, "")
           expect(response.success?).to eq expected_value
@@ -48,10 +48,10 @@ Spec2.describe Cossack::Response do
 
     describe "#redirection?" do
       it "returns true for 3xx responses" do
-        { 299 => false,
-          300 => true,
-          399 => true,
-          400 => false
+        {299 => false,
+         300 => true,
+         399 => true,
+         400 => false,
         }.each do |status, expected_value|
           response = Cossack::Response.new(status, "")
           expect(response.redirection?).to eq expected_value
@@ -61,10 +61,10 @@ Spec2.describe Cossack::Response do
 
     describe "#client_error?" do
       it "returns true for 3xx responses" do
-        { 399 => false,
-          400 => true,
-          499 => true,
-          500 => false
+        {399 => false,
+         400 => true,
+         499 => true,
+         500 => false,
         }.each do |status, expected_value|
           response = Cossack::Response.new(status, "")
           expect(response.client_error?).to eq expected_value
@@ -74,10 +74,10 @@ Spec2.describe Cossack::Response do
 
     describe "#server_error?" do
       it "returns true for 3xx responses" do
-        { 499 => false,
-          500 => true,
-          599 => true,
-          600 => false
+        {499 => false,
+         500 => true,
+         599 => true,
+         600 => false,
         }.each do |status, expected_value|
           response = Cossack::Response.new(status, "")
           expect(response.server_error?).to eq expected_value

--- a/src/cossack.cr
+++ b/src/cossack.cr
@@ -5,6 +5,7 @@ require "./cossack/**"
 
 module Cossack
   alias Params = Hash(String, String)
+  alias BodyType = String | Bytes | IO | Nil
 
   # Common Cossack error.
   class Error < Exception; end

--- a/src/cossack/client.cr
+++ b/src/cossack/client.cr
@@ -5,7 +5,7 @@ module Cossack
     @base_uri : URI
     @headers : HTTP::Headers
     @cookies : CookieJar
-    @app : Middleware|Connection|Proc(Request, Response)
+    @app : Middleware | Connection | Proc(Request, Response)
 
     getter :base_uri, :headers, :request_options, :connection, :cookies
 
@@ -31,7 +31,7 @@ module Cossack
       @app = @middlewares.last
     end
 
-    def connection=(conn : Proc(Request, Response)|Connection)
+    def connection=(conn : Proc(Request, Response) | Connection)
       @connection = conn
       if @middlewares.first?
         @middlewares.first.__set_app__(@connection)
@@ -69,20 +69,18 @@ module Cossack
       end
     {% end %}
 
-
     {% for method in %w(post put patch) %}
-      def {{method.id}}(url : String, body : String = "")
+      def {{method.id}}(url : String, body : BodyType = "")
         {{method.id}}(url, body) { }
       end
 
-      def {{method.id}}(url : String, body : String = "")
+      def {{method.id}}(url : String, body : BodyType = "")
         uri = complete_uri!(URI.parse(url))
         request = Request.new("{{method.id.upcase}}", uri, @headers.dup, body, @request_options.dup)
         yield(request)
         call(request)
       end
     {% end %}
-
 
     private def default_headers
       HTTP::Headers.new.tap do |headers|

--- a/src/cossack/connection/http_connection.cr
+++ b/src/cossack/connection/http_connection.cr
@@ -6,7 +6,7 @@ module Cossack
       client.connect_timeout = request.options.connect_timeout
       client.read_timeout = request.options.read_timeout
 
-      http_response = client.exec(request.method, request.uri.to_s, request.headers, request.body)
+      http_response = client.exec(request.method, request.uri.path, request.headers, request.body)
       Response.new(http_response.status_code, http_response.headers, http_response.body)
     rescue err : IO::TimeoutError
       raise TimeoutError.new(err.message, cause: err)

--- a/src/cossack/connection/http_connection.cr
+++ b/src/cossack/connection/http_connection.cr
@@ -8,7 +8,7 @@ module Cossack
 
       http_response = client.exec(request.method, request.uri.to_s, request.headers, request.body)
       Response.new(http_response.status_code, http_response.headers, http_response.body)
-    rescue err : IO::Timeout
+    rescue err : IO::TimeoutError
       raise TimeoutError.new(err.message, cause: err)
     end
   end

--- a/src/cossack/connection/test_connection.cr
+++ b/src/cossack/connection/test_connection.cr
@@ -26,7 +26,7 @@ module Cossack
       end
 
       error_message = <<-MESSAGE
-      Request `#{request.method} #{request.uri.to_s}` is not stubbed.
+      Request `#{request.method} #{request.uri}` is not stubbed.
       You can stub it with the following code:\n
           connection.stub_#{request.method.downcase}("#{request.uri.path}", {200, "Response body"})
         OR

--- a/src/cossack/connection/test_connection/request_matcher.cr
+++ b/src/cossack/connection/test_connection/request_matcher.cr
@@ -1,13 +1,13 @@
 module Cossack
   class TestConnection < Connection
     class RequestMatcher
-      def initialize(@method : String? = nil, uri : URI?|String? = nil, @headers = {} of String => String, @body : String? = nil)
+      def initialize(@method : String? = nil, uri : URI? | String? = nil, @headers = {} of String => String, @body : String? = nil)
         @uri = uri ? URI.parse(uri) : URI.new
       end
 
       def matches?(request : Request)
         return false if @method && @method != request.method
-        return false if @body   && @body   != request.body
+        return false if @body && @body != request.body
 
         {% for uri_part in %w(scheme host port user password path query) %}
           return false if @uri.{{uri_part.id}} && @uri.{{uri_part.id}} != request.uri.{{uri_part.id}}

--- a/src/cossack/cookie_jar.cr
+++ b/src/cossack/cookie_jar.cr
@@ -26,29 +26,18 @@ module Cossack
       # imports from Set-Cookie header values
       tmp_headers = HTTP::Headers.new
       File.each_line(file_path) do |line|
-        next unless line.strip.size == 0
+        next if line.strip.size == 0
         tmp_headers.add("Set-Cookie", line.strip)
       end
-
       fill_from_headers(tmp_headers) unless tmp_headers.empty?
     end
 
-    # OVERRIDE
-
-    # The methods below as they appear in the Std Library (as of v0.18.7) add a
-    # header that is blank if the cookie jar is empty instead of not adding any
-    # header at all.
-
-    def add_request_headers(headers)
-      super(headers) unless empty?
-
-      headers
-    end
-
-    def add_response_headers(headers)
-      super(headers) unless empty?
-
-      headers
+    def self.from(cookies : HTTP::Cookies)
+      s = new
+      cookies.each do |c|
+        s << c
+      end
+      s
     end
   end
 end

--- a/src/cossack/cookie_jar.cr
+++ b/src/cossack/cookie_jar.cr
@@ -8,7 +8,7 @@ module Cossack
   # domain, http_only, and path restrictions
   class CookieJar < HTTP::Cookies
     def self.from_file(file_path : String)
-      new.tap {|cj| cj.import_from_file(file_path) }
+      new.tap { |cj| cj.import_from_file(file_path) }
     end
 
     def export_to_file(file_path : String)

--- a/src/cossack/middleware/middleware.cr
+++ b/src/cossack/middleware/middleware.cr
@@ -2,7 +2,7 @@ module Cossack
   abstract class Middleware
     abstract def call(request : Request) : Response
 
-    @app : Middleware|Connection|Proc(Request, Response)
+    @app : Middleware | Connection | Proc(Request, Response)
 
     getter :app
 

--- a/src/cossack/request.cr
+++ b/src/cossack/request.cr
@@ -2,26 +2,26 @@ module Cossack
   # Request built by Client, that can be processed by middleware and a connection.
   #
   # ```
-  # request.method  # => "POST"
-  # request.uri     # => #<URI:0x11b8ea0 @scheme="http", @host="example.org" ...>
-  # request.body    # => "payload"
-  # request.headers # => #<HTTP::Headers ... >
-  # request.options.connect_timeout  # => 30
-  # request.options.read_timeout     # => 30
+  # request.method                  # => "POST"
+  # request.uri                     # => #<URI:0x11b8ea0 @scheme="http", @host="example.org" ...>
+  # request.body                    # => "payload"
+  # request.headers                 # => #<HTTP::Headers ... >
+  # request.options.connect_timeout # => 30
+  # request.options.read_timeout    # => 30
   # ```
   class Request
     @method : String
     @uri : URI
     @headers : HTTP::Headers
-    @body : String?
+    @body : BodyType
     @options : RequestOptions
 
     property :method, :uri, :headers, :body, :options
 
-    def initialize(@method : String, @uri : URI, @headers : HTTP::Headers = HTTP::Headers.new, @body : String? = nil, @options = RequestOptions.new)
+    def initialize(@method : String, @uri : URI, @headers : HTTP::Headers = HTTP::Headers.new, @body : BodyType = nil, @options = RequestOptions.new)
     end
 
-    def initialize(@method : String, uri : String, @headers : HTTP::Headers = HTTP::Headers.new, @body : String? = nil, @options = RequestOptions.new)
+    def initialize(@method : String, uri : String, @headers : HTTP::Headers = HTTP::Headers.new, @body : BodyType = nil, @options = RequestOptions.new)
       @uri = URI.parse(uri)
     end
   end

--- a/src/cossack/request_options.cr
+++ b/src/cossack/request_options.cr
@@ -3,16 +3,16 @@ module Cossack
     property connect_timeout : Float64
     property read_timeout : Float64
 
-    def initialize(connect_timeout : Number|Time::Span = 30.0, read_timeout : Number|Time::Span = 30.0)
+    def initialize(connect_timeout : Number | Time::Span = 30.0, read_timeout : Number | Time::Span = 30.0)
       @connect_timeout = connect_timeout.to_f
       @read_timeout = read_timeout.to_f
     end
 
-    def connect_timeout=(val : Number|Time::Span)
+    def connect_timeout=(val : Number | Time::Span)
       @connect_timeout = val.to_f
     end
 
-    def read_timeout=(val : Number|Time::Span)
+    def read_timeout=(val : Number | Time::Span)
       @read_timeout = val.to_f
     end
   end

--- a/src/cossack/response.cr
+++ b/src/cossack/response.cr
@@ -28,7 +28,6 @@ module Cossack
       @headers = HTTP::Headers.new
     end
 
-
     # Is this a 2xx response?
     def success?
       (200..299).includes?(status)


### PR DESCRIPTION
Body with String type was more restrictive and for arbitrary large binary files, it required to read everything into String and then invoke Request method. Crystal HTTP::Request also accepts the same modified Body types.